### PR TITLE
Fix maximum rotation value in GetBoardRotation()

### DIFF
--- a/src/lib/sensor_calibration/Utilities.cpp
+++ b/src/lib/sensor_calibration/Utilities.cpp
@@ -222,7 +222,7 @@ enum Rotation GetBoardRotation()
 	int32_t board_rot = -1;
 	param_get(param_find("SENS_BOARD_ROT"), &board_rot);
 
-	if (board_rot >= 0 && board_rot <= Rotation::ROTATION_MAX) {
+	if (board_rot >= 0 && board_rot < Rotation::ROTATION_MAX) {
 		return static_cast<enum Rotation>(board_rot);
 
 	} else {


### PR DESCRIPTION
Fix a memory overflow in case SENS_BOARD_ROT is set to Rotation::ROTATION_MAX (41) which is not a valid value

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When ... I found that ...

Fixes #{Github issue ID}

### Solution
- Add ... for ...
- Refactor ...

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
